### PR TITLE
URL with puppy name and sliding animation not impacted

### DIFF
--- a/layouts/puppies/list.html
+++ b/layouts/puppies/list.html
@@ -99,11 +99,13 @@
   // Close instant articles
   var closeInst = name => {
     const instArt = document.querySelector('article#'+name)
+    const urlnew = window.location.href
     instant.classList.remove('active')
     console.log(instArt)
     setTimeout(() => {
       instArt.classList.remove('active')
     }, 250);
+    window.history.replaceState(urlnew, "puppies","/puppies/")
   }
 </script>
 {{ end }}

--- a/layouts/puppies/list.html
+++ b/layouts/puppies/list.html
@@ -67,7 +67,7 @@
   let instant = document.querySelector('section.instant-wrap')
   {{ range .Pages }}
   {{ $link := replaceRE " " "-" (.Title | lower) }}
-  getHTML('/puppies/{{ $link }}',2000,(response) => {
+    getHTML('/puppies/{{ $link }}',2000,(response) => {
     const post = response.querySelector('article.post.instant')
     instant.append(post)
   });
@@ -76,15 +76,15 @@
   // Activate instant articles on click
   let openArtLink = document.querySelectorAll('a.button.instant')
   openArtLink.forEach(link => {
-    link.removeAttribute('href')
-    link.addEventListener('click', () => {
+     // link.removeAttribute('href')
+      link.addEventListener('click', () => {
       const data = link.getAttribute('data-instant')
       const instArt = document.querySelector('article#'+data)
       const img = instArt.querySelectorAll('figure > img')
       instant.classList.add('active')
       instArt.classList.add('active')
       img.forEach(i => {
-        const l = i.getAttribute('data-src')
+      const l = i.getAttribute('data-src')
         i.setAttribute('src',l)
         i.classList.add('loaded')
       })

--- a/layouts/puppies/list.html
+++ b/layouts/puppies/list.html
@@ -37,6 +37,7 @@
 {{ end }}
 {{ define "scripts" }}
 <script>
+    
     var getHTML = (url, timeout, callback) => {
     // Feature detection
     if ( !window.XMLHttpRequest ) return;
@@ -74,9 +75,11 @@
   {{ end }}
 
   // Activate instant articles on click
+  
   let openArtLink = document.querySelectorAll('a.button.instant')
   openArtLink.forEach(link => {
-     // link.removeAttribute('href')
+      const url = link.getAttribute('href')
+      link.removeAttribute('href')
       link.addEventListener('click', () => {
       const data = link.getAttribute('data-instant')
       const instArt = document.querySelector('article#'+data)
@@ -88,8 +91,10 @@
         i.setAttribute('src',l)
         i.classList.add('loaded')
       })
+      console.log(url + "LOADED \n");
+      window.history.replaceState(url, data,"/puppies/"+data)
+     })
     })
-  })
 
   // Close instant articles
   var closeInst = name => {

--- a/layouts/puppies/single.html
+++ b/layouts/puppies/single.html
@@ -3,7 +3,7 @@
   <main class="single frenchie">
     {{ $name := replaceRE " " "-" (.Title | lower) }}
     <article id="{{ $name }}" class="post instant">
-      <a class="button close-instant" style="display:block" onclick="closeInst({{ $name }})">Close Article</a>
+      <a class="button close-instant"  onclick="closeInst({{ $name }})">Close Article</a>
       {{ $img := resources.Get (print "img/puppies/" (.Params.image)) }}
       <figure class="hero-wrap" style="background-image: url('{{ $img.Permalink }}')">
         <div class="overlay"></div>
@@ -18,7 +18,7 @@
       <section class="content">
         <p>{{ .Content }}</p>
       </section>
-      <a class="button close-instant" style="display:block" onclick="closeInst({{ $name }})">Close Article</a>
+      <a class="button close-instant"  onclick="closeInst({{ $name }})">Close Article</a>
     </article>
   </main>
   {{ partial "footer.html" . }}

--- a/layouts/puppies/single.html
+++ b/layouts/puppies/single.html
@@ -3,7 +3,7 @@
   <main class="single frenchie">
     {{ $name := replaceRE " " "-" (.Title | lower) }}
     <article id="{{ $name }}" class="post instant">
-      <a class="button close-instant" onclick="closeInst({{ $name }})">Close Article</a>
+      <a class="button close-instant" style="display:block" onclick="closeInst({{ $name }})">Close Article</a>
       {{ $img := resources.Get (print "img/puppies/" (.Params.image)) }}
       <figure class="hero-wrap" style="background-image: url('{{ $img.Permalink }}')">
         <div class="overlay"></div>
@@ -18,7 +18,7 @@
       <section class="content">
         <p>{{ .Content }}</p>
       </section>
-      <a class="button close-instant" onclick="closeInst({{ $name }})">Close Article</a>
+      <a class="button close-instant" style="display:block" onclick="closeInst({{ $name }})">Close Article</a>
     </article>
   </main>
   {{ partial "footer.html" . }}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "imagemin-pngquant": "^7.0.0",
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack-plugin": "^2.4.2",
-    "npm": "6.7.0",
+    "npm": "^6.4.1",
     "postcss-calc": "^7.0.1",
     "postcss-cli": "^6.0.0",
     "postcss-custom-properties": "^8.0.9",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "prettier": "^1.16.4",
     "script-loader": "^0.7.2",
     "sugarss": "^2.0.0",
+    "vanilla-router": "^1.2.7",
     "webpack": "^4.29.5",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.0"


### PR DESCRIPTION
Using the replaceState function of HTML5, the puppy name is included in the url of the single puppy page and also the sliding anim
![pup-Greta](https://user-images.githubusercontent.com/37545009/54637176-60a02500-4a5e-11e9-9195-a7100acaebf6.png)
ation is intact.